### PR TITLE
use createCheckMenuItem to allow menu ctrl+click

### DIFF
--- a/src/cvRange.hpp
+++ b/src/cvRange.hpp
@@ -293,12 +293,15 @@ struct CVRange {
 				};
 
 				for(int pi = 0; pi < PRESET_COUNT; pi ++){
-					bool checkmark = (min == preset[pi].min) && ((min + range) == preset[pi].max);
-					menu->addChild(createMenuItem(preset[pi].label, CHECKMARK(checkmark), [=]() { 
-						cv_a = preset[pi].min;
-						cv_b = preset[pi].max;
-						updateInternal();
-					}));
+					menu->addChild(createCheckMenuItem(preset[pi].label, "",
+						[=]() {
+							return (min == preset[pi].min) && ((min + range) == preset[pi].max);
+						},
+						[=]() {
+							cv_a = preset[pi].min;
+							cv_b = preset[pi].max;
+							updateInternal();
+						}));
 				}
 			}
 		));


### PR DESCRIPTION
using Rack's createCheckMenuItem() function instead of the base createMenuItem() for boolean/checkmark/toggle menu items allows the user to ctrl-click on menu items to toggle them while also updating the menu to reflect the changes, instead of having to close and reopen the menu to see said changes.